### PR TITLE
[Nephos] Update SDK version to support new kernel module 3.16.0-5

### DIFF
--- a/platform/nephos/sdk.mk
+++ b/platform/nephos/sdk.mk
@@ -1,4 +1,4 @@
-NEPHOS_NPS_KERNEL = nps-modules-3.16.0-4-amd64_2.0.3a63-20180110_amd64.deb
-$(NEPHOS_NPS_KERNEL)_URL = "https://github.com/NephosInc/SONiC/raw/master/sdk/nps-modules-3.16.0-4-amd64_2.0.3a63-20180110_amd64.deb"
+NEPHOS_NPS_KERNEL = nps-modules-3.16.0-5-amd64_2.0.3_amd64.deb
+$(NEPHOS_NPS_KERNEL)_URL = "https://github.com/NephosInc/SONiC/raw/master/sdk/nps-modules-3.16.0-5-amd64_2.0.3_amd64.deb"
 
 SONIC_ONLINE_DEBS += $(NEPHOS_NPS_KERNEL)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Upgrading SDK version from 3.16.0-4 to 3.16.0-5 on Nephos platform

**- How I did it**
Updating sdk.mk in platform/nephos

**- How to verify it**
Checking system and network feature is worked on Nephos platform

**- Description for the changelog**
Update SDK version to support new kernel module 3.16.0-5
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
