### PR TITLE
[mellanox]: Update URL for SDK

### DIFF
--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -1,4 +1,4 @@
-MLNX_SDK_BASE_URL = https://github.com/Mellanox/SAI-Implementation/raw/564703412781016766b248b98266bd6f2c161431/sdk
+MLNX_SDK_BASE_URL = https://github.com/Mellanox/SAI-Implementation/raw/645052b0a285b190082beb858ba43a8b33bb667a/sdk
 MLNX_SDK_VERSION = 4.2.6011
 MLNX_SDK_RDEBS += $(APPLIBS) $(IPROUTE2_MLNX) $(SX_ACL_RM) $(SX_COMPLIB) \
 		  $(SX_EXAMPLES) $(SX_GEN_UTILS) $(SX_SCEW) $(SX_SDN_HAL) \


### PR DESCRIPTION
New URL includes sx-kernel compatible with Linux 3.16.0-5

Signed-off-by: marian-pritsak <marianp@mellanox.com>