### PR TITLE
Removing deployment id filter from router advertiser

### DIFF
--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -47,17 +47,15 @@ dependent_startup_wait_for=rsyslogd:running
 {# at least one VLAN interface which has an IPv6 address asigned #}
 {# But not for specific deployment_id #}
 {%- set vlan_v6 = namespace(count=0) -%}
-{%- if DEVICE_METADATA.localhost.deployment_id != "8" -%}
-  {%- if DEVICE_METADATA.localhost.type -%}
-    {%- if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type in ["EPMS", "MgmtTsToR"] -%}
-      {%- if VLAN_INTERFACE -%}
-        {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
-          {# If this VLAN has an IPv6 address... #}
-          {%- if prefix | ipv6 -%}
-            {%- set vlan_v6.count = vlan_v6.count + 1 -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
+{%- if DEVICE_METADATA.localhost.type -%}
+  {%- if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type in ["EPMS", "MgmtTsToR"] -%}
+    {%- if VLAN_INTERFACE -%}
+      {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
+        {# If this VLAN has an IPv6 address... #}
+        {%- if prefix | ipv6 -%}
+          {%- set vlan_v6.count = vlan_v6.count + 1 -%}
+        {%- endif -%}
+      {%- endfor -%}
     {%- endif -%}
   {%- endif -%}
 {%- endif -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202205
- [x] 202211
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

